### PR TITLE
Added attached dep. props CellTemplate and CellEditingTemplate

### DIFF
--- a/Gu.Wpf.DataGrid2D.sln
+++ b/Gu.Wpf.DataGrid2D.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{70700050-2381-499E-AD41-69BFE55B22EE}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "0.", "0.", "{70700050-2381-499E-AD41-69BFE55B22EE}"
 	ProjectSection(SolutionItems) = preProject
 		paket.dependencies = paket.dependencies
 		paket.lock = paket.lock

--- a/Gu.Wpf.DataGrid2D/Gu.Wpf.DataGrid2D.csproj
+++ b/Gu.Wpf.DataGrid2D/Gu.Wpf.DataGrid2D.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Internals\BindingHelper.cs" />
     <Compile Include="Internals\BooleanBoxes.cs" />
     <Compile Include="Internals\ColumnHeaderListener.cs" />
+    <Compile Include="Internals\CustomDataGridTemplateColumn.cs" />
     <Compile Include="Internals\EnumerableExt.cs" />
     <Compile Include="Internals\Helpers.cs" />
     <Compile Include="Internals\RoutedEventHelper.cs" />
@@ -55,6 +56,8 @@
     <Compile Include="Internals\RowsListener.cs" />
     <Compile Include="Internals\TypeExt.cs" />
     <Compile Include="ItemsSource.Array2DTransposed.cs" />
+    <Compile Include="ItemsSource.CellEditingTemplate.cs" />
+    <Compile Include="ItemsSource.CellTemplate.cs" />
     <Compile Include="ItemsSource.RowHeadersSource.cs" />
     <Compile Include="ItemsSource.ColumnsSource.cs" />
     <Compile Include="ItemsSource.Shared.cs" />

--- a/Gu.Wpf.DataGrid2D/Gu.Wpf.DataGrid2D.ruleset
+++ b/Gu.Wpf.DataGrid2D/Gu.Wpf.DataGrid2D.ruleset
@@ -75,4 +75,10 @@
     <Rule Id="SA1615" Action="None" />
     <Rule Id="SA1633" Action="None" />
   </Rules>
+  <Rules AnalyzerId="WpfAnalyzers.Analyzers" RuleNamespace="WpfAnalyzers.Analyzers">
+    <Rule Id="WA1200" Action="Error" />
+    <Rule Id="WA1201" Action="Error" />
+    <Rule Id="WA1202" Action="Error" />
+    <Rule Id="WA1210" Action="Error" />
+  </Rules>
 </RuleSet>

--- a/Gu.Wpf.DataGrid2D/Internals/CustomDataGridTemplateColumn.cs
+++ b/Gu.Wpf.DataGrid2D/Internals/CustomDataGridTemplateColumn.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace Gu.Wpf.DataGrid2D.Internals
+{
+    internal class CustomDataGridTemplateColumn : DataGridTemplateColumn
+    {
+        private BindingBase _binding;
+
+        protected virtual void OnBindingChanged(BindingBase oldBinding, BindingBase newBinding)
+        {
+            base.NotifyPropertyChanged("Binding");
+        }
+
+        public virtual BindingBase Binding
+        {
+            get
+            {
+                return this._binding;
+            }
+            set
+            {
+                if (this._binding != value)
+                {
+                    BindingBase oldBinding = this._binding;
+                    this._binding = value;
+                    base.CoerceValue(DataGridColumn.SortMemberPathProperty);
+                    this.OnBindingChanged(oldBinding, this._binding);
+                }
+            }
+        }
+
+        public override BindingBase ClipboardContentBinding
+        {
+            get
+            {
+                return (base.ClipboardContentBinding ?? this.Binding);
+            }
+            set
+            {
+                base.ClipboardContentBinding = value;
+            }
+        }
+
+        private DataTemplate ChooseCellTemplate(bool isEditing)
+        {
+            DataTemplate template = null;
+            if (isEditing)
+            {
+                template = this.CellEditingTemplate;
+            }
+            if (template == null)
+            {
+                template = this.CellTemplate;
+            }
+            return template;
+        }
+
+        private DataTemplateSelector ChooseCellTemplateSelector(bool isEditing)
+        {
+            DataTemplateSelector templateSelector = null;
+            if (isEditing)
+            {
+                templateSelector = this.CellEditingTemplateSelector;
+            }
+            if (templateSelector == null)
+            {
+                templateSelector = this.CellTemplateSelector;
+            }
+            return templateSelector;
+        }
+
+        protected override FrameworkElement GenerateEditingElement(DataGridCell cell, object dataItem)
+        {
+            return this.LoadTemplateContent(true, dataItem, cell);
+        }
+
+        protected override FrameworkElement GenerateElement(DataGridCell cell, object dataItem)
+        {
+            return this.LoadTemplateContent(false, dataItem, cell);
+        }
+
+        private void ApplyBinding(DependencyObject target, DependencyProperty property)
+        {
+            BindingBase binding = this.Binding;
+            if (binding != null)
+            {
+                BindingOperations.SetBinding(target, property, binding);
+            }
+            else
+            {
+                BindingOperations.SetBinding(target, property, new Binding());
+            }
+        }
+
+        private FrameworkElement LoadTemplateContent(bool isEditing, object dataItem, DataGridCell cell)
+        {
+            DataTemplate template = this.ChooseCellTemplate(isEditing);
+            DataTemplateSelector templateSelector = this.ChooseCellTemplateSelector(isEditing);
+            if ((template == null) && (templateSelector == null))
+            {
+                return null;
+            }
+            ContentPresenter contentPresenter = new ContentPresenter();
+            this.ApplyBinding(contentPresenter, ContentPresenter.ContentProperty);
+            contentPresenter.ContentTemplate = template;
+            contentPresenter.ContentTemplateSelector = templateSelector;
+            return contentPresenter;
+        }
+    }
+}

--- a/Gu.Wpf.DataGrid2D/ItemsSource.Array2D.cs
+++ b/Gu.Wpf.DataGrid2D/ItemsSource.Array2D.cs
@@ -30,6 +30,7 @@
         private static void OnArray2DChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var dataGrid = (DataGrid)d;
+            dataGrid.AutoGeneratingColumn -= DataGrid_AutoGeneratingColumn;
             var array = (Array)e.NewValue;
             if (array == null)
             {

--- a/Gu.Wpf.DataGrid2D/ItemsSource.Array2D.cs
+++ b/Gu.Wpf.DataGrid2D/ItemsSource.Array2D.cs
@@ -39,6 +39,7 @@
             }
 
             var array2DView = Array2DView.Create(array);
+            dataGrid.AutoGeneratingColumn += DataGrid_AutoGeneratingColumn;
             dataGrid.Bind(ItemsControl.ItemsSourceProperty)
                     .OneWayTo(array2DView);
             dataGrid.AutoGeneratingColumn += DataGrid_AutoGeneratingColumn;

--- a/Gu.Wpf.DataGrid2D/ItemsSource.Array2D.cs
+++ b/Gu.Wpf.DataGrid2D/ItemsSource.Array2D.cs
@@ -39,9 +39,9 @@
             }
 
             var array2DView = Array2DView.Create(array);
-            dataGrid.AutoGeneratingColumn += DataGrid_AutoGeneratingColumn;
             dataGrid.Bind(ItemsControl.ItemsSourceProperty)
                     .OneWayTo(array2DView);
+            dataGrid.AutoGeneratingColumn += DataGrid_AutoGeneratingColumn;
             dataGrid.RaiseEvent(new RoutedEventArgs(Events.ColumnsChanged));
         }
 

--- a/Gu.Wpf.DataGrid2D/ItemsSource.Array2D.cs
+++ b/Gu.Wpf.DataGrid2D/ItemsSource.Array2D.cs
@@ -1,5 +1,6 @@
 ﻿namespace Gu.Wpf.DataGrid2D
 {
+    using Internals;
     using System;
     using System.Windows;
     using System.Windows.Controls;
@@ -37,9 +38,26 @@
             }
 
             var array2DView = Array2DView.Create(array);
+            dataGrid.AutoGeneratingColumn += DataGrid_AutoGeneratingColumn;
             dataGrid.Bind(ItemsControl.ItemsSourceProperty)
                     .OneWayTo(array2DView);
             dataGrid.RaiseEvent(new RoutedEventArgs(Events.ColumnsChanged));
+        }
+
+        private static void DataGrid_AutoGeneratingColumn(object sender, DataGridAutoGeneratingColumnEventArgs e)
+        {
+            CustomDataGridTemplateColumn col = new CustomDataGridTemplateColumn();
+            col.CellTemplate = (DataTemplate)((DataGrid)sender).GetCellTemplate();
+            col.CellEditingTemplate = (DataTemplate)((DataGrid)sender).GetCellEditingTemplate();
+            if (col.CellTemplate != null && col.CellEditingTemplate != null)
+            {
+                DataGridTextColumn tc = e.Column as DataGridTextColumn;
+                if (tc != null && tc.Binding != null)
+                {
+                    col.Binding = tc.Binding;
+                    e.Column = col;
+                }
+            }
         }
 
         private static bool OnValidateArray2D(object value)

--- a/Gu.Wpf.DataGrid2D/ItemsSource.Array2DTransposed.cs
+++ b/Gu.Wpf.DataGrid2D/ItemsSource.Array2DTransposed.cs
@@ -37,6 +37,7 @@
             }
 
             var array2DView = Array2DView.CreateTransposed(array);
+            dataGrid.AutoGeneratingColumn += DataGrid_AutoGeneratingColumn;
             dataGrid.Bind(ItemsControl.ItemsSourceProperty)
                     .OneWayTo(array2DView);
             dataGrid.RaiseEvent(new RoutedEventArgs(Events.ColumnsChanged));

--- a/Gu.Wpf.DataGrid2D/ItemsSource.Array2DTransposed.cs
+++ b/Gu.Wpf.DataGrid2D/ItemsSource.Array2DTransposed.cs
@@ -29,6 +29,7 @@
         private static void OnArray2DTransposedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var dataGrid = (DataGrid)d;
+            dataGrid.AutoGeneratingColumn -= DataGrid_AutoGeneratingColumn;
             var array = (Array)e.NewValue;
             if (array == null)
             {

--- a/Gu.Wpf.DataGrid2D/ItemsSource.CellEditingTemplate.cs
+++ b/Gu.Wpf.DataGrid2D/ItemsSource.CellEditingTemplate.cs
@@ -28,7 +28,11 @@
 
         private static void OnCellEditingTemplateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            // TODO
+            var dataGrid = (DataGrid)d;
+            var celltemplate = (DataTemplate)e.NewValue;
+
+            dataGrid.SetCellEditingTemplate(celltemplate);
+            dataGrid.RaiseEvent(new RoutedEventArgs(Events.ColumnsChanged));
         }
 
         private static bool OnValidateCellEditingTemplate(object value)

--- a/Gu.Wpf.DataGrid2D/ItemsSource.CellEditingTemplate.cs
+++ b/Gu.Wpf.DataGrid2D/ItemsSource.CellEditingTemplate.cs
@@ -1,0 +1,39 @@
+﻿namespace Gu.Wpf.DataGrid2D
+{
+    using System;
+    using System.Windows;
+    using System.Windows.Controls;
+    using System.Windows.Data;
+
+    public static partial class ItemsSource
+    {
+        public static readonly DependencyProperty CellEditingTemplateProperty = DependencyProperty.RegisterAttached(
+            "CellEditingTemplate",
+            typeof(DataTemplate),
+            typeof(ItemsSource),
+            new PropertyMetadata(null, OnCellEditingTemplateChanged),
+            OnValidateCellEditingTemplate);
+
+        public static void SetCellEditingTemplate(this DataGrid element, DataTemplate value)
+        {
+            element.SetValue(CellEditingTemplateProperty, value);
+        }
+
+        [AttachedPropertyBrowsableForChildren(IncludeDescendants = false)]
+        [AttachedPropertyBrowsableForType(typeof(DataGrid))]
+        public static DataTemplate GetCellEditingTemplate(this DataGrid element)
+        {
+            return (DataTemplate)element.GetValue(CellEditingTemplateProperty);
+        }
+
+        private static void OnCellEditingTemplateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            // TODO
+        }
+
+        private static bool OnValidateCellEditingTemplate(object value)
+        {
+            return true;
+        }
+    }
+}

--- a/Gu.Wpf.DataGrid2D/ItemsSource.CellTemplate.cs
+++ b/Gu.Wpf.DataGrid2D/ItemsSource.CellTemplate.cs
@@ -28,7 +28,11 @@
         
         private static void OnCellTemplateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            // TODO
+            var dataGrid = (DataGrid)d;
+            var celltemplate = (DataTemplate)e.NewValue;
+            
+            dataGrid.SetCellTemplate(celltemplate);
+            dataGrid.RaiseEvent(new RoutedEventArgs(Events.ColumnsChanged));
         }
         
         private static bool OnValidateCellTemplate(object value)

--- a/Gu.Wpf.DataGrid2D/ItemsSource.CellTemplate.cs
+++ b/Gu.Wpf.DataGrid2D/ItemsSource.CellTemplate.cs
@@ -1,0 +1,39 @@
+﻿namespace Gu.Wpf.DataGrid2D
+{
+    using System;
+    using System.Windows;
+    using System.Windows.Controls;
+    using System.Windows.Data;
+
+    public static partial class ItemsSource
+    {
+        public static readonly DependencyProperty CellTemplateProperty = DependencyProperty.RegisterAttached(
+            "CellTemplate",
+            typeof(DataTemplate),
+            typeof(ItemsSource),
+            new PropertyMetadata(null, OnCellTemplateChanged),
+            OnValidateCellTemplate);
+        
+        public static void SetCellTemplate(this DataGrid element, DataTemplate value)
+        {
+            element.SetValue(CellTemplateProperty, value);
+        }
+        
+        [AttachedPropertyBrowsableForChildren(IncludeDescendants = false)]
+        [AttachedPropertyBrowsableForType(typeof(DataGrid))]
+        public static DataTemplate GetCellTemplate(this DataGrid element)
+        {
+            return (DataTemplate)element.GetValue(CellTemplateProperty);
+        }
+        
+        private static void OnCellTemplateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            // TODO
+        }
+        
+        private static bool OnValidateCellTemplate(object value)
+        {
+            return true;
+        }
+    }
+}

--- a/paket.lock
+++ b/paket.lock
@@ -4,15 +4,15 @@ GROUP Analyzers
 FRAMEWORK: >= NET45
 NUGET
   remote: http://www.nuget.org/api/v2
-    JetBrains.Annotations (10.2.1)
+    JetBrains.Annotations (10.1.5)
     StyleCop.Analyzers (1.0)
-    WpfAnalyzers (0.2.4-dev)
+    WpfAnalyzers (0.1.6.3-dev)
 
 GROUP Test
 FRAMEWORK: >= NET45
 NUGET
   remote: http://www.nuget.org/api/v2
     Castle.Core (3.3.3)
-    NUnit (3.5)
+    NUnit (3.4.1)
     TestStack.White (0.13.3)
       Castle.Core (>= 3.3)


### PR DESCRIPTION
Like we discussed: the new properties can be used to specify a custom template for the cells of the colums of the 2D grid. It causes the grid to use TemplateColumns instead of TextColumns while autogenerating columns.