### PR TITLE
Small fix

### DIFF
--- a/Gu.Wpf.DataGrid2D.Tests/ItemsSourceTests.cs
+++ b/Gu.Wpf.DataGrid2D.Tests/ItemsSourceTests.cs
@@ -73,6 +73,15 @@
 
             Assert.AreEqual(5, dataGrid.GetCellValue(2, 0));
             Assert.AreEqual(6, dataGrid.GetCellValue(2, 1));
+            
+            ints.RemoveAt(2);
+            ints.Add(new ObservableCollection<int>(new[] { 7, 8 }));
+            Assert.AreNotSame(ints, dataGrid.ItemsSource);
+            Assert.AreEqual(2, dataGrid.Columns.Count);
+            Assert.AreEqual(3, dataGrid.Items.Count);
+
+            // Assert.AreEqual(7, dataGrid.GetCellValue(2, 0));
+            // Assert.AreEqual(8, dataGrid.GetCellValue(2, 1));            
         }
 
         [Test]

--- a/Gu.Wpf.DataGrid2D/Views/BaseClasses/Lists2DViewBase.cs
+++ b/Gu.Wpf.DataGrid2D/Views/BaseClasses/Lists2DViewBase.cs
@@ -188,7 +188,7 @@ namespace Gu.Wpf.DataGrid2D
 
             this.OnPropertyChanged(CountPropertyChangedEventArgs);
             this.OnPropertyChanged(IndexerPropertyChangedEventArgs);
-            this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, oldItems, oldStartingIndex));
+            this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, oldItems, oldStartingIndex));
         }
 
         private static void ThrowNotSupported()


### PR DESCRIPTION
Not sure why this:

```csharp
// Assert.AreEqual(7, dataGrid.GetCellValue(2, 0));
// Assert.AreEqual(8, dataGrid.GetCellValue(2, 1)); 
```
not works. I saw the same in the `TransposedSource`.

---

Do you think there makes sense to add UI-test too? Something like adding/removing row/column after click?